### PR TITLE
Added vscode container config and Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:18.04
+
+# Get some extra bits for ubuntu to allow add-apt-repository
+RUN apt-get update \
+	&& apt-get install -y \
+		software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+# Intall Go
+RUN add-apt-repository ppa:longsleep/golang-backports \
+	&& apt-get update \
+	&& apt-get install -y \
+		gcc make \
+		golang-go
+
+RUN mkdir /root/go
+ENV GOPATH=/root/go
+ENV GOBIN=$GOPATH/bin
+
+# Install node 10 and other key dependancies
+RUN apt-get update \
+	&& apt-get install -y \
+		curl \
+	&& curl --silent --location https://deb.nodesource.com/setup_10.x | bash -
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+		python3-pip \
+		python3-setuptools \
+		ssh \
+		git \
+		nodejs \
+		jq \
+		unzip \		
+	&& pip3 install --upgrade pip \
+	&& pip install awscli --upgrade \
+	&& npm install -g npm@latest \
+	&& npm install -g serverless \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Install latest version of terraform
+RUN TERRAFORM_LATEST=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version') \
+	&& curl -q "https://releases.hashicorp.com/terraform/${TERRAFORM_LATEST}/terraform_${TERRAFORM_LATEST}_linux_amd64.zip" --output /tmp/terraform.zip \
+	&& unzip /tmp/terraform.zip -d /usr/local/bin \
+	&& chmod +x /usr/local/bin/terraform \
+	&& rm /tmp/terraform.zip

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "Dockerfile",
+
+	// The optional 'runArgs' property can be used to specify additional runtime arguments.
+	"runArgs": [
+		// Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-in-docker for details.
+		// "-v","/var/run/docker.sock:/var/run/docker.sock",
+
+		// Uncomment the next line if you will be using a ptrace-based debugger like C++, Go, and Rust.
+		// "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
+
+		// You may want to add a non-root user to your Dockerfile. On Linux, this will prevent
+		// new files getting created as root. See https://aka.ms/vscode-remote/containers/non-root-user
+		// for the needed Dockerfile updates and then uncomment the next line.
+		// "-u", "vscode"
+	],
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		// This will ignore your local shell user setting for Linux since shells like zsh are typically 
+		// not in base container images. You can also update this to an specific shell to ensure VS Code 
+		// uses the right one for terminals and tasks. For example, /bin/bash (or /bin/ash for Alpine).
+		"terminal.integrated.shell.linux": null
+	},
+
+	// Uncomment the next line if you want to publish any ports.
+	// "appPort": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing git.
+	// "postCreateCommand": "apt-get update && apt-get install -y git",
+
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": []
+}


### PR DESCRIPTION
If you're running on Windows you can get VS Code to run your session inside a docker container.  You just need docker for windows and the remote container extension (https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed.  Makes it much easier with missing dependencies and OS issues.

The Dockerfile in the pull request has most stuff needed to run the sessions (worked fine for the StepFuntions 101)